### PR TITLE
Install python3 modules on base AMI.

### DIFF
--- a/provisioners/shell/packages.sh
+++ b/provisioners/shell/packages.sh
@@ -17,6 +17,9 @@ DEPS="
     aria2
     gdb
     ruby2.5
+    python3-pip
+    python3-boto
+    python3-boto3
     "
 
 # Install basic packages


### PR DESCRIPTION
Instaill pip, boto and boto3 modules in packages.sh.