### PR TITLE
Add Base AMI release tag to builders.

### DIFF
--- a/provisioners/shell/chrony.sh
+++ b/provisioners/shell/chrony.sh
@@ -25,6 +25,6 @@ systemctl restart chrony
 
 echo "Verifying Amazon Time Sync Service..."
 # waiting until source being determined
-sleep 10
+sleep 30
 chronyc tracking |grep $AMAZON_NTP_IP &> /dev/null
 echo "ok"

--- a/templates/base.json
+++ b/templates/base.json
@@ -24,7 +24,8 @@
       "Name": "{{user `ami_name`}}",
       "OS": "Ubuntu Server",
       "OS Version": "{{user `tag_os_version`}}",
-      "Base AMI": "{{user `source_ami`}}"
+      "Base AMI": "{{user `source_ami`}}",
+      "Base AMI Release": "{{user `source_ami_release`}}"
     }
   }],
   "provisioners": [{

--- a/templates/salt-master.json
+++ b/templates/salt-master.json
@@ -23,7 +23,8 @@
         "Name": "{{user `ami_name`}}",
         "OS": "Ubuntu Server",
         "OS Version": "{{user `tag_os_version`}}",
-        "Base AMI": "{{user `source_ami`}}"
+        "Base AMI": "{{user `source_ami`}}",
+        "Base AMI Release": "{{user `source_ami_release`}}"
       }
     }],
     "provisioners": [{


### PR DESCRIPTION
Add Base AMI release tag to builders.
Give it more time to restart chrony before excecute chronyc tracking.